### PR TITLE
Folia compatibility

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ api-version: 1.13
 main: com.straight8.rambeau.bukkit.PluginVersionsBukkit
 description: List installed plugins and versions alphabetically
 authors: [drives_a_ford, GabrielHD150, SlimeDog]
+folia-supported: true
 
 commands:
   pluginversions:


### PR DESCRIPTION
folia-supported: true

Of course, this PR should not be merged until Folia is actually available for testing and supported. There will be a significant ramp before the major plugins are updated to support Folia.

Since this plugin does not manipulate chunks, operating through the `global region` thread should be relatively simple. An example of how to perform this magic may be found [here](https://github.com/ViaVersion/ViaVersion/blob/master/bukkit/src/main/java/com/viaversion/viaversion/ViaVersionPlugin.java).